### PR TITLE
Save opinfos across translations

### DIFF
--- a/src/hg_instrument.h
+++ b/src/hg_instrument.h
@@ -61,11 +61,12 @@
 
 // Instrument a single statement, adding the instrumented statements
 // to sbOut.
-void instrumentStatement(IRStmt* st, IRSB* sbOut, Addr stAddr);
+void instrumentStatement(IRStmt* st, IRSB* sbOut, Addr stAddr, int opNum);
 
 // Add instrumenting expressions to sb for an operation, storing the
 // result in the temporary at offset.
-void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr);
+void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr, int opNum);
+Op_Info* populateOpInfo(Addr opAddr, int opNum, int nargs, SizeT arg_size, SizeT result_size, IROp op);
 
 // Get the plain name of the op, like "subtraction"
 const HChar* getPlainOpname(IROp op);
@@ -86,4 +87,7 @@ void finalizeBlock(IRSB* sbOut);
 // VEX's type system.
 int isFloat(IRTypeEnv* env, IRTemp temp);
 int isFloatType(IRType type);
+
+Bool isOp(IRStmt* st);
+void init_instrumentation(void);
 #endif

--- a/src/hg_instrumentOp.c
+++ b/src/hg_instrumentOp.c
@@ -173,12 +173,12 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
                            getOpSymbol(expr->Iex.Unop.op));
 
         // Populate the argument/result values we know at instrument time now.
-        opInfo->args.uargs.arg_tmp = getArgTmp(expr->Iex.Unop.arg, sb);
+        opInfo->arg_tmps[0] = getArgTmp(expr->Iex.Unop.arg, sb);
         opInfo->dest_tmp = offset;
 
         // Allocate the space for the values we won't know until
         // runtime, but know their size now.
-        ALLOC(opInfo->args.uargs.arg_value,
+        ALLOC(opInfo->arg_values[0],
               "hg.arg_alloc", 1, arg_size);
         ALLOC(opInfo->dest_value,
               "hg.arg_alloc", 1, result_size);
@@ -186,7 +186,7 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
         // Add statements to populate the values we don't know until
         // runtime.
         addStore(sb, expr->Iex.Unop.arg,
-                 &(opInfo->args.uargs.arg_value));
+                 &(opInfo->arg_values[0]));
         addStore(sb, IRExpr_RdTmp(offset),
                  &(opInfo->dest_value));
 
@@ -323,17 +323,17 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
                            getOpSymbol(expr->Iex.Binop.op));
 
         // Populate the argument/result values we know at instrument time now.
-        opInfo->args.bargs.arg1_tmp =
+        opInfo->arg_tmps[0] =
           getArgTmp(expr->Iex.Binop.arg1, sb);
-        opInfo->args.bargs.arg2_tmp =
+        opInfo->arg_tmps[1] =
           getArgTmp(expr->Iex.Binop.arg2, sb);
         opInfo->dest_tmp = offset;
 
         // Allocate the space for the values we won't know until
         // runtime, but know their size now.
-        ALLOC(opInfo->args.bargs.arg1_value,
+        ALLOC(opInfo->arg_values[0],
               "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->args.bargs.arg2_value,
+        ALLOC(opInfo->arg_values[1],
               "hg.arg_alloc", 1, arg_size);
         ALLOC(opInfo->dest_value,
               "hg.arg_alloc", 1, result_size);
@@ -341,9 +341,9 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
         // Add statements to populate the values we don't know until
         // runtime.
         addStore(sb, expr->Iex.Binop.arg1,
-                 opInfo->args.bargs.arg1_value);
+                 opInfo->arg_values[0]);
         addStore(sb, expr->Iex.Binop.arg2,
-                 opInfo->args.bargs.arg2_value);
+                 opInfo->arg_values[1]);
         addStore(sb, IRExpr_RdTmp(offset),
                  opInfo->dest_value);
 
@@ -467,21 +467,21 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
                            getOpSymbol(expr->Iex.Triop.details->op));
 
         // Populate the values we know at instrument time now.
-        opInfo->args.targs.arg1_tmp =
+        opInfo->arg_tmps[0] =
           getArgTmp(expr->Iex.Triop.details->arg1, sb);
-        opInfo->args.targs.arg2_tmp =
+        opInfo->arg_tmps[1] =
           getArgTmp(expr->Iex.Triop.details->arg2, sb);
-        opInfo->args.targs.arg3_tmp =
+        opInfo->arg_tmps[2] =
           getArgTmp(expr->Iex.Triop.details->arg3, sb);
         opInfo->dest_tmp = offset;
 
         // Allocate the space for the values we won't know until
         // runtime, but know their size now.
-        ALLOC(opInfo->args.targs.arg1_value,
+        ALLOC(opInfo->arg_values[0],
               "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->args.targs.arg2_value,
+        ALLOC(opInfo->arg_values[1],
               "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->args.targs.arg3_value,
+        ALLOC(opInfo->arg_values[2],
               "hg.arg_alloc", 1, arg_size);
         ALLOC(opInfo->dest_value,
               "hg.arg_alloc", 1, result_size);
@@ -489,11 +489,11 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
         // Add statements to populate the values we don't know until
         // runtime.
         addStore(sb, expr->Iex.Triop.details->arg1,
-                 opInfo->args.targs.arg1_value);
+                 opInfo->arg_values[0]);
         addStore(sb, expr->Iex.Triop.details->arg2,
-                 opInfo->args.targs.arg2_value);
+                 opInfo->arg_values[1]);
         addStore(sb, expr->Iex.Triop.details->arg3,
-                 opInfo->args.targs.arg3_value);
+                 opInfo->arg_values[2]);
         addStore(sb, IRExpr_RdTmp(offset),
                  opInfo->dest_value);
 
@@ -551,25 +551,25 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
 
         // Populate the values we know at instrument time now.
         opInfo->op = expr->Iex.Qop.details->op;
-        opInfo->args.qargs.arg1_tmp =
+        opInfo->arg_tmps[0] =
           getArgTmp(expr->Iex.Qop.details->arg1, sb);
-        opInfo->args.qargs.arg2_tmp =
+        opInfo->arg_tmps[1] =
           getArgTmp(expr->Iex.Qop.details->arg2, sb);
-        opInfo->args.qargs.arg3_tmp =
+        opInfo->arg_tmps[2] =
           getArgTmp(expr->Iex.Qop.details->arg3, sb);
-        opInfo->args.qargs.arg4_tmp =
+        opInfo->arg_tmps[3] =
           getArgTmp(expr->Iex.Qop.details->arg4, sb);
         opInfo->dest_tmp = offset;
 
         // Allocate the space for the values we won't know until
         // runtime, but know their size now.
-        ALLOC(opInfo->args.qargs.arg1_value,
+        ALLOC(opInfo->arg_values[0],
               "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->args.qargs.arg2_value,
+        ALLOC(opInfo->arg_values[1],
               "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->args.qargs.arg3_value,
+        ALLOC(opInfo->arg_values[2],
               "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->args.qargs.arg4_value,
+        ALLOC(opInfo->arg_values[3],
               "hg.arg_alloc", 1, arg_size);
         ALLOC(opInfo->dest_value,
               "hg.arg_alloc", 1, result_size);
@@ -577,13 +577,13 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
         // Add statements to populate the values we don't know until
         // runtime.
         addStore(sb, expr->Iex.Qop.details->arg1,
-                 opInfo->args.qargs.arg1_value);
+                 opInfo->arg_values[0]);
         addStore(sb, expr->Iex.Qop.details->arg2,
-                 opInfo->args.qargs.arg2_value);
+                 opInfo->arg_values[1]);
         addStore(sb, expr->Iex.Qop.details->arg3,
-                 opInfo->args.qargs.arg3_value);
+                 opInfo->arg_values[2]);
         addStore(sb, expr->Iex.Qop.details->arg3,
-                 opInfo->args.qargs.arg4_value);
+                 opInfo->arg_values[3]);
         addStore(sb, IRExpr_RdTmp(offset),
                  opInfo->dest_value);
 

--- a/src/hg_instrumentOp.c
+++ b/src/hg_instrumentOp.c
@@ -30,10 +30,16 @@
 
 #include "hg_instrument.h"
 #include "include/hg_macros.h"
+#include "pub_tool_hashtable.h"
+#include "pub_tool_xarray.h"
+#include "pub_tool_libcassert.h"
+
+VgHashTable* opinfo_store;
 
 // Add instrumenting expressions to sb for an operation, storing the
-// result in the temporary at offset.
-void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
+// result in the temporary at offset. opNum is a zero-based index of
+// which op this is in the current instruction translation.
+void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr, int opNum){
   IRDirty* executeShadowOp;
   SizeT arg_size, result_size;
   (void)executeShadowOp;
@@ -166,22 +172,14 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
       case Iop_NegF64:
       case Iop_AbsF64:
       case Iop_Sqrt64F0x2:
-        // Allocate and partially setup the argument structure
-        opInfo = mkOp_Info(1, expr->Iex.Unop.op,
-                           opAddr,
-                           getPlainOpname(expr->Iex.Unop.op),
-                           getOpSymbol(expr->Iex.Unop.op));
+        opInfo = populateOpInfo(opAddr, opNum, 1, arg_size, result_size, expr->Iex.Unop.op);
 
-        // Populate the argument/result values we know at instrument time now.
+        // Populate the argument/result temporaries we know at
+        // instrument time now. This might change between
+        // instrumentations of the same operation, so we write it
+        // even if there's an existing entry.
         opInfo->arg_tmps[0] = getArgTmp(expr->Iex.Unop.arg, sb);
         opInfo->dest_tmp = offset;
-
-        // Allocate the space for the values we won't know until
-        // runtime, but know their size now.
-        ALLOC(opInfo->arg_values[0],
-              "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->dest_value,
-              "hg.arg_alloc", 1, result_size);
 
         // Add statements to populate the values we don't know until
         // runtime.
@@ -316,11 +314,7 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
       case Iop_SetV128lo32:
       case Iop_SetV128lo64:
       case Iop_XorV128:
-        // Allocate and partially setup the argument structure
-        opInfo = mkOp_Info(2, expr->Iex.Binop.op,
-                           opAddr,
-                           getPlainOpname(expr->Iex.Binop.op),
-                           getOpSymbol(expr->Iex.Binop.op));
+        opInfo = populateOpInfo(opAddr, opNum, 2, arg_size, result_size, expr->Iex.Binop.op);
 
         // Populate the argument/result values we know at instrument time now.
         opInfo->arg_tmps[0] =
@@ -328,15 +322,6 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
         opInfo->arg_tmps[1] =
           getArgTmp(expr->Iex.Binop.arg2, sb);
         opInfo->dest_tmp = offset;
-
-        // Allocate the space for the values we won't know until
-        // runtime, but know their size now.
-        ALLOC(opInfo->arg_values[0],
-              "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->arg_values[1],
-              "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->dest_value,
-              "hg.arg_alloc", 1, result_size);
 
         // Add statements to populate the values we don't know until
         // runtime.
@@ -461,10 +446,7 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
       case Iop_SubF64r32:
       case Iop_MulF64r32:
       case Iop_DivF64r32:
-        // Allocate and partially setup the argument structure
-        opInfo = mkOp_Info(3, expr->Iex.Triop.details->op, opAddr,
-                           getPlainOpname(expr->Iex.Triop.details->op),
-                           getOpSymbol(expr->Iex.Triop.details->op));
+        opInfo = populateOpInfo(opAddr, opNum, 3, arg_size, result_size, expr->Iex.Triop.details->op);
 
         // Populate the values we know at instrument time now.
         opInfo->arg_tmps[0] =
@@ -474,17 +456,6 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
         opInfo->arg_tmps[2] =
           getArgTmp(expr->Iex.Triop.details->arg3, sb);
         opInfo->dest_tmp = offset;
-
-        // Allocate the space for the values we won't know until
-        // runtime, but know their size now.
-        ALLOC(opInfo->arg_values[0],
-              "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->arg_values[1],
-              "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->arg_values[2],
-              "hg.arg_alloc", 1, arg_size);
-        ALLOC(opInfo->dest_value,
-              "hg.arg_alloc", 1, result_size);
 
         // Add statements to populate the values we don't know until
         // runtime.
@@ -544,13 +515,9 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
       case Iop_MSubF64:
       case Iop_MAddF64r32:
       case Iop_MSubF64r32:
-        // Allocate and partially setup the argument structure
-        opInfo = mkOp_Info(4, expr->Iex.Qop.details->op, opAddr,
-                           getPlainOpname(expr->Iex.Qop.details->op),
-                           getOpSymbol(expr->Iex.Qop.details->op));
+        opInfo = populateOpInfo(opAddr, opNum, 4, arg_size, result_size, expr->Iex.Qop.details->op);
 
         // Populate the values we know at instrument time now.
-        opInfo->op = expr->Iex.Qop.details->op;
         opInfo->arg_tmps[0] =
           getArgTmp(expr->Iex.Qop.details->arg1, sb);
         opInfo->arg_tmps[1] =
@@ -603,6 +570,44 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
   default:
     VG_(dmsg)("BAD THINGS!!!!\n");
     break;
+  }
+}
+
+// This function tries to lookup a previously created opinfo for the
+// op, identified by the address in client code and which op it is in
+// the translation of that structure. If it can't find an existing
+// op_info, it creates a new one, and saves it for next time.
+Op_Info* populateOpInfo(Addr opAddr, int opNum, int nargs, SizeT arg_size, SizeT result_size, IROp op){
+  Op_Infos_ptr* entry = VG_(HT_lookup)(opinfo_store, opAddr);
+  if (entry == NULL){
+    ALLOC(entry, "hg.op_infos_entry", 1, sizeof(Op_Infos_ptr));
+    entry->addr = opAddr;
+    entry->infos = VG_(newXA)(VG_(malloc), "op_infos",
+                              VG_(free), sizeof(Op_Info*));
+    VG_(HT_add_node)(opinfo_store, entry);
+  }
+  if (VG_(sizeXA)(entry->infos) <= opNum){
+    // Allocate and partially setup the argument structure
+    Op_Info* opInfo = mkOp_Info(nargs, op,
+                                opAddr,
+                                getPlainOpname(op),
+                                getOpSymbol(op));
+
+    // Allocate the space for the values we won't know until
+    // runtime, but know their size now.
+    for (int i = 0; i < nargs; ++i){
+      ALLOC(opInfo->arg_values[i],
+            "hg.arg_alloc", 1, arg_size);
+    }
+    ALLOC(opInfo->dest_value,
+          "hg.arg_alloc", 1, result_size);
+    VG_(addToXA)(entry->infos, &opInfo);
+    tl_assert(opInfo->arg_tmps != NULL);
+    return opInfo;
+  } else {
+    Op_Info* opInfo = *(Op_Info**)(VG_(indexXA)(entry->infos, opNum));
+    tl_assert(opInfo->arg_tmps != NULL);
+    return opInfo;
   }
 }
 

--- a/src/hg_instrumentOp.c
+++ b/src/hg_instrumentOp.c
@@ -186,9 +186,9 @@ void instrumentOp(IRSB* sb, Int offset, IRExpr* expr, Addr opAddr){
         // Add statements to populate the values we don't know until
         // runtime.
         addStore(sb, expr->Iex.Unop.arg,
-                 &(opInfo->arg_values[0]));
+                 opInfo->arg_values[0]);
         addStore(sb, IRExpr_RdTmp(offset),
-                 &(opInfo->dest_value));
+                 opInfo->dest_value);
 
         // Finally, add the statement to call the shadow op procedure.
         executeShadowOp =

--- a/src/hg_main.c
+++ b/src/hg_main.c
@@ -89,8 +89,13 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
     // statement.
     if (st->tag == Ist_IMark)
       cur_addr = st->Ist.IMark.addr;
-    // Take a look at hg_instrument.c to see what's going on here.
-    instrumentStatement(st, sbOut, cur_addr);
+    // Only instrument statements after the preamble, not before the
+    // first IMark.
+    if (cur_addr)
+      // Take a look at hg_instrument.c to see what's going on here.
+      instrumentStatement(st, sbOut, cur_addr, opNum);
+    else
+      addStmtToIRSB(sbOut, st);
   }
 
   // Add instrumentation that cleans up per-block state.

--- a/src/hg_main.c
+++ b/src/hg_main.c
@@ -61,9 +61,8 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
                       const VexArchInfo* archinfo_host,
                       IRType gWordTy, IRType hWordTy )
 {
-  // For right now, just print out the VEX representation as we
-  // process it.
-
+  // Print out the input blocks if the appropriate flags have been
+  // turned on.
   if (print_in_blocks && running){
     VG_(printf)("Instrumenting block:\n");
     printSuperBlock(bb);
@@ -76,9 +75,11 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
   // as well as some info about the exit jump, from the old superblock.
   IRSB* sbOut = deepCopyIRSBExceptStmts(bb);
 
+  // Add instrumentation that initializes per-block state.
   startBlock(sbOut);
 
-  // The address cooresponding to the statement we're currently instrumenting.
+  // The address cooresponding to the statement we're currently
+  // instrumenting.
   Addr cur_addr = 0x0;
   // Now, let's loop through these statements, and instrument them to
   // add our shadow values.
@@ -92,8 +93,11 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
     instrumentStatement(st, sbOut, cur_addr);
   }
 
+  // Add instrumentation that cleans up per-block state.
   finalizeBlock(sbOut);
 
+  // Print out the output blocks, if the appropriate flags have been
+  // turned on.
   if (print_out_blocks && running){
     VG_(printf)("Instrumented into:\n");
     printSuperBlock(sbOut);

--- a/src/hg_main.c
+++ b/src/hg_main.c
@@ -81,14 +81,17 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
   // The address cooresponding to the statement we're currently
   // instrumenting.
   Addr cur_addr = 0x0;
+  int opNum = 0;
   // Now, let's loop through these statements, and instrument them to
   // add our shadow values.
   for (int i = 0; i < bb->stmts_used; i++){
     IRStmt* st = bb->stmts[i];
     // Use the IMarks to get a cooresponding address for each
     // statement.
-    if (st->tag == Ist_IMark)
+    if (st->tag == Ist_IMark){
       cur_addr = st->Ist.IMark.addr;
+      opNum = 0;
+    }
     // Only instrument statements after the preamble, not before the
     // first IMark.
     if (cur_addr)
@@ -96,6 +99,8 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
       instrumentStatement(st, sbOut, cur_addr, opNum);
     else
       addStmtToIRSB(sbOut, st);
+    if (isOp(st))
+      opNum ++;
   }
 
   // Add instrumentation that cleans up per-block state.
@@ -216,6 +221,7 @@ static void hg_fini(Int exitcode){
 // This does any initialization that needs to be done after command
 // line processing.
 static void hg_post_clo_init(void){
+   init_instrumentation();
    // Set up the data structures we'll need to keep track of our MPFR
    // shadow values.
    init_runtime();

--- a/src/runtime/hg_mathreplace.c
+++ b/src/runtime/hg_mathreplace.c
@@ -155,42 +155,7 @@ void performOp(OpType op, double* result, double* args){
     Op_Info** src_loc_slot;
     // Get the slot in the op info structure for the value source
     // structure cooresponding to this argument.
-    switch(nargs){
-    case 1:
-      src_loc_slot = &(entry->info->args.uargs.arg_src);
-      break;
-    case 2:
-      switch(i){
-      case 0:
-        src_loc_slot = &(entry->info->args.bargs.arg1_src);
-        break;
-      case 1:
-        src_loc_slot = &(entry->info->args.bargs.arg2_src);
-        break;
-      default:
-        VG_(dmsg)("BAD THINGS!");
-        return;
-      }
-      break;
-    case 3:
-      switch(i){
-      case 0:
-        src_loc_slot = &(entry->info->args.targs.arg1_src);
-        break;
-      case 1:
-        src_loc_slot = &(entry->info->args.targs.arg2_src);
-        break;
-      case 2:
-        src_loc_slot = &(entry->info->args.targs.arg3_src);
-        break;
-      default:
-        VG_(dmsg)("BAD THINGS!");
-        return;
-      }
-    default:
-        VG_(dmsg)("BAD THINGS!");
-      return;
-    }
+    src_loc_slot = &(entry->info->arg_srcs[i]);
     // Lookup the address in our shadow hash table to get the shadow
     // argument.
     arg_shadows[i] = getShadowValMem((uintptr_t)&(args[i]), args[i],

--- a/src/types/hg_opinfo.c
+++ b/src/types/hg_opinfo.c
@@ -54,6 +54,9 @@ Op_Info* mkOp_Info(SizeT arity, IROp op, Addr opAddr,
                    const HChar* name, const HChar* symbol){
   Op_Info* result;
   ALLOC(result, "hg.op_info.1", 1, sizeof(Op_Info));
+  ALLOC(result->arg_tmps, "hg.op_tmps", arity, sizeof(UWord));
+  ALLOC(result->arg_values, "hg.op_values", arity, sizeof(UWord*));
+  ALLOC(result->arg_srcs, "hg.op_srcs", arity, sizeof(Op_Info**));
   result->tag = Op_Branch;
   result->nargs = arity;
   result->op = op;
@@ -78,12 +81,10 @@ Op_Info* mkOp_Info(SizeT arity, IROp op, Addr opAddr,
 
 Op_Info* mkLeafOp_Info(ShadowValue* val){
   Op_Info* result;
-  OpASTNode* ast;
   ALLOC(result, "leaf op", 1, sizeof(Op_Info));
-  ALLOC(ast, "leaf op ast", 1, sizeof(OpASTNode*));
-  ast->nd.Leaf.val = NULL;
-  initOpLeafAST(ast, val);
+  ALLOC(result->ast, "ast", 1, sizeof(OpASTNode));
+  initOpLeafAST(result->ast, val);
+  result->ast->nd.Leaf.val = NULL;
   result->tag = Op_Leaf;
-  result->ast = ast;
   return result;
 }

--- a/src/types/hg_opinfo.h
+++ b/src/types/hg_opinfo.h
@@ -92,98 +92,6 @@ struct _Eval_Info {
 };
 
 typedef enum {
-  Unary,
-  Binary,
-  Ternary,
-  Quadnary
-} Arity;
-
-struct _Unary_Args {
-  // This is the index of the temporary that holds these values. We'll
-  // use this index to index into the shadow value array too.
-  UWord arg_tmp;
-  // If we don't have a shadow value yet for these arguments, we're
-  // going to use the existing float value to create one. This float
-  // value can be as big as 256 bits, since we account for SIMD
-  // locations, so we're going to store it as an array that's
-  // malloc'd when we know how big it's going to be.
-  UWord* arg_value;
-  // If the argument didn't come from the result of another operation,
-  // than we'll keep track of the "source" of that argument as a leaf
-  // operation here.
-  Op_Info* arg_src;
-};
-
-struct _Binary_Args {
-  // These are the indicies of the temporaries that hold these
-  // values. We'll use these indices to index into the shadow value
-  // array too.
-  UWord arg1_tmp;
-  UWord arg2_tmp;
-  // If we don't have a shadow value yet for these arguments, we're
-  // going to use the existing float values to create one. These float
-  // values can be as big as 256 bits, since we account for SIMD
-  // locations, so we're going to store them as an array that's
-  // malloc'd when we know how big they're going to be.
-  UWord* arg1_value;
-  UWord* arg2_value;
-  // If the argument didn't come from the result of another operation,
-  // than we'll keep track of the "source" of that argument as a leaf
-  // operation here.
-  Op_Info* arg1_src;
-  Op_Info* arg2_src;
-};
-
-struct _Ternary_Args {
-  // These are the indicies of the temporaries that hold these
-  // values. We'll use these indices to index into the shadow value
-  // array too.
-  UWord arg1_tmp;
-  UWord arg2_tmp;
-  UWord arg3_tmp;
-  // If we don't have a shadow value yet for these arguments, we're
-  // going to use the existing float values to create one. These float
-  // values can be as big as 256 bits, since we account for SIMD
-  // locations, so we're going to store them as an array that's
-  // malloc'd when we know how big they're going to be.
-  UWord* arg1_value;
-  UWord* arg2_value;
-  UWord* arg3_value;
-  // If the argument didn't come from the result of another operation,
-  // than we'll keep track of the "source" of that argument as a leaf
-  // operation here.
-  Op_Info* arg1_src;
-  Op_Info* arg2_src;
-  Op_Info* arg3_src;
-};
-
-struct _Quadnary_Args {
-  // These are the indicies of the temporaries that hold these
-  // values. We'll use these indices to index into the shadow value
-  // array too.
-  UWord arg1_tmp;
-  UWord arg2_tmp;
-  UWord arg3_tmp;
-  UWord arg4_tmp;
-  // If we don't have a shadow value yet for these arguments, we're
-  // going to use the existing float values to create one. These float
-  // values can be as big as 256 bits, since we account for SIMD
-  // locations, so we're going to store them as an array that's
-  // malloc'd when we know how big they're going to be.
-  UWord* arg1_value;
-  UWord* arg2_value;
-  UWord* arg3_value;
-  UWord* arg4_value;
-  // If the argument didn't come from the result of another operation,
-  // than we'll keep track of the "source" of that argument as a leaf
-  // operation here.
-  Op_Info* arg1_src;
-  Op_Info* arg2_src;
-  Op_Info* arg3_src;
-  Op_Info* arg4_src;
-};
-
-typedef enum {
   Op_Branch,
   Op_Leaf,
 } OpInfoType;
@@ -209,12 +117,23 @@ struct _Op_Info {
   // accuracy.
   UWord* dest_value;
   // The argument information for the op
-  union {
-    Unary_Args uargs;
-    Binary_Args bargs;
-    Ternary_Args targs;
-    Quadnary_Args qargs;
-  } args;
+
+  // These are the indicies of the temporaries that hold these
+  // values. We'll use these indices to index into the shadow value
+  // array too.
+  UWord* arg_tmps;
+
+  // If we don't have a shadow value yet for these arguments, we're
+  // going to use the existing float values to create one. These float
+  // values can be as big as 256 bits, since we account for SIMD
+  // locations, so we're going to store them as an array that's
+  // malloc'd when we know how big they're going to be.
+  UWord** arg_values;
+
+  // If the argument didn't come from the result of another operation,
+  // than we'll keep track of the "source" of that argument as a leaf
+  // operation here.
+  Op_Info** arg_srcs;
 };
 
 Op_Info* mkOp_Info(SizeT arity, IROp op, Addr opAddr,

--- a/src/types/hg_opinfo.h
+++ b/src/types/hg_opinfo.h
@@ -37,6 +37,7 @@
 
 #include "pub_tool_basics.h"
 #include "pub_tool_tooliface.h"
+#include "pub_tool_xarray.h"
 
 // When I was looking through the FpDebug source as inspiration for
 // this project, I kept seeing these structures all over the place
@@ -134,6 +135,18 @@ struct _Op_Info {
   // than we'll keep track of the "source" of that argument as a leaf
   // operation here.
   Op_Info** arg_srcs;
+};
+
+struct _Op_Infos_ptr {
+  // This member is here to make this structure compatible with the
+  // hash table implementation in pub_tool_hashtable. None of our code
+  // will actually use it.
+  struct _Op_Infos_ptr* next;
+  // This part is also here for the hash table structure, but we'll
+  // actually be messing with it as we'll set it to the key.
+  UWord addr;
+  // The actual opinfo we're pointing too.
+  XArray* infos;
 };
 
 Op_Info* mkOp_Info(SizeT arity, IROp op, Addr opAddr,

--- a/src/types/hg_opinfo.hh
+++ b/src/types/hg_opinfo.hh
@@ -42,5 +42,6 @@ typedef struct _Binary_Args Binary_Args;
 typedef struct _Ternary_Args Ternary_Args;
 typedef struct _Quadnary_Args Quadnary_Args;
 typedef struct _Op_Info Op_Info;
+typedef struct _Op_Infos_ptr Op_Infos_ptr;
 
 #endif


### PR DESCRIPTION
Sometimes valgrind will instrument the same block more than once, or
even instrument overlapping blocks at different times. This saves the
persistent state (tracking statistics about error and asts) for
operations across different translations of it.

This also comes with some bugfixes and cleanup.