### PR TITLE
Do comparisons in the reals by default

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -73,6 +73,7 @@ Bool only_improvable = False;
 Bool var_swallow = True;
 Bool unsound_var_swallow = False;
 Bool follow_real_execution = False;
+Bool double_comparisons = False;
 Bool use_ranges = True;
 
 Bool no_exprs = False;
@@ -110,6 +111,7 @@ Bool hg_process_cmd_line_option(const HChar* arg){
   else if VG_XACT_CLO(arg, "--no-var-swallow", var_swallow, False) {}
   else if VG_XACT_CLO(arg, "--unsound-var-swallow", unsound_var_swallow, True) {}
   else if VG_XACT_CLO(arg, "--follow-real-execution", follow_real_execution, False) {}
+  else if VG_XACT_CLO(arg, "--double-comparisons", double_comparisons, True) {}
   else if VG_XACT_CLO(arg, "--expr-colors", expr_colors, True) {}
   else if VG_XACT_CLO(arg, "--output-mark-exprs", output_mark_exprs, True) {}
   else if VG_XACT_CLO(arg, "--detailed-ranges", detailed_ranges, True) {}

--- a/src/options.h
+++ b/src/options.h
@@ -74,6 +74,7 @@ extern Bool only_improvable;
 extern Bool var_swallow;
 extern Bool unsound_var_swallow;
 extern Bool follow_real_execution;
+extern Bool double_comparisons;
 
 extern Bool no_exprs;
 extern Bool no_influences;

--- a/src/runtime/shadowop/exit-float-op.c
+++ b/src/runtime/shadowop/exit-float-op.c
@@ -40,60 +40,114 @@ VG_REGPARM(1) void checkCompare(ShadowCmpInfo* info){
   }
   int correctOutput;
   if (numSIMDOperands(info->op_code) == 1){
-    double correctFst = getDouble(args[0]->values[0]->real);
-    double correctSnd = getDouble(args[1]->values[0]->real);
-    switch(info->op_code){
-    case Iop_CmpF64:
-    case Iop_CmpF32:{
-      if (correctFst != correctFst ||
-          correctSnd != correctSnd){
-        correctOutput = 0x45;
-      } else if (correctFst < correctSnd){
-        correctOutput = 0x01;
-      } else if (correctFst > correctSnd){
-        correctOutput = 0x00;
-      } else {
-        correctOutput = 0x40;
+    if (double_comparisons){
+      double correctFst = getDouble(args[0]->values[0]->real);
+      double correctSnd = getDouble(args[1]->values[0]->real);
+      switch(info->op_code){
+      case Iop_CmpF64:
+      case Iop_CmpF32:{
+        if (correctFst != correctFst ||
+            correctSnd != correctSnd){
+          correctOutput = 0x45;
+        } else if (correctFst < correctSnd){
+          correctOutput = 0x01;
+        } else if (correctFst > correctSnd){
+          correctOutput = 0x00;
+        } else {
+          correctOutput = 0x40;
+        }
       }
-    }
-      break;
-    case Iop_CmpLT32F0x4:
-    case Iop_CmpLT64F0x2: {
-      if (correctFst != correctFst ||
-          correctSnd != correctSnd){
-        correctOutput = 0x0;
-      } else if (correctFst < correctSnd){
-        correctOutput = 0x01;
-      } else if (correctFst > correctSnd){
-        correctOutput = 0x00;
-      } else {
-        correctOutput = 0x00;
+        break;
+      case Iop_CmpLT32F0x4:
+      case Iop_CmpLT64F0x2: {
+        if (correctFst != correctFst ||
+            correctSnd != correctSnd){
+          correctOutput = 0x0;
+        } else if (correctFst < correctSnd){
+          correctOutput = 0x01;
+        } else if (correctFst > correctSnd){
+          correctOutput = 0x00;
+        } else {
+          correctOutput = 0x00;
+        }
       }
-    }
-      break;
-    case Iop_CmpLE64F0x2: {
-      if (correctFst != correctFst ||
-          correctSnd != correctSnd) {
-        correctOutput = 0x00;
-      } else if (correctFst <= correctSnd) {
-        correctOutput = 0x01;
-      } else {
-        correctOutput = 0x00;
+        break;
+      case Iop_CmpLE64F0x2: {
+        if (correctFst != correctFst ||
+            correctSnd != correctSnd) {
+          correctOutput = 0x00;
+        } else if (correctFst <= correctSnd) {
+          correctOutput = 0x01;
+        } else {
+          correctOutput = 0x00;
+        }
       }
-    }
-      break;
-    case Iop_CmpUN64F0x2:
-    case Iop_CmpUN32F0x4:{
-      if (correctFst == correctSnd){
-        correctOutput = 0x01;
-      } else {
-        correctOutput = 0x00;
+        break;
+      case Iop_CmpUN64F0x2:
+      case Iop_CmpUN32F0x4:{
+        if (correctFst == correctSnd){
+          correctOutput = 0x01;
+        } else {
+          correctOutput = 0x00;
+        }
       }
-    }
-      break;
-    default:
-      tl_assert(0);
-      return;
+        break;
+      default:
+        tl_assert(0);
+        return;
+      }
+    } else {
+      Real realFst = args[0]->values[0]->real;
+      Real realSnd = args[1]->values[0]->real;
+      switch(info->op_code){
+      case Iop_CmpF64:
+      case Iop_CmpF32:{
+        if (isNaN(realFst) || isNaN(realSnd)){
+          correctOutput = 0x45;
+        } else if (realCompare(realFst, realSnd) < 0){
+          correctOutput = 0x01;
+        } else if (realCompare(realFst, realSnd) > 0){
+          correctOutput = 0x00;
+        } else {
+          correctOutput = 0x40;
+        }
+      }
+      case Iop_CmpLT32F0x4:
+      case Iop_CmpLT64F0x2: {
+        if (isNaN(realFst) || isNaN(realSnd)){
+          correctOutput = 0x0;
+        } else if (realCompare(realFst, realSnd) < 0){
+          correctOutput = 0x01;
+        } else if (realCompare(realFst, realSnd) > 0){
+          correctOutput = 0x00;
+        } else {
+          correctOutput = 0x00;
+        }
+      }
+        break;
+      case Iop_CmpLE64F0x2: {
+        if (isNaN(realFst) || isNaN(realSnd)){
+          correctOutput = 0x00;
+        } else if (realCompare(realFst, realSnd) <= 0) {
+          correctOutput = 0x01;
+        } else {
+          correctOutput = 0x00;
+        }
+      }
+        break;
+      case Iop_CmpUN64F0x2:
+      case Iop_CmpUN32F0x4:{
+        if (realCompare(realFst, realSnd) == 0){
+          correctOutput = 0x01;
+        } else {
+          correctOutput = 0x00;
+        }
+      }
+        break;
+      default:
+        tl_assert(0);
+        return;
+      }
     }
   } else {
     tl_assert(0);

--- a/src/runtime/value-shadowstate/real.c
+++ b/src/runtime/value-shadowstate/real.c
@@ -72,7 +72,14 @@ int isNaN(Real real){
   #ifdef USE_MPFR
   return mpfr_nan_p(real->mpfr_val);
   #else
-  return mpf_nan_p(real->mpfr_val);
+  return mpf_nan_p(real->mpf_val);
+  #endif
+}
+int realCompare(Real real1, Real real2){
+  #ifdef USE_MPFR
+  return mpfr_cmp(real1->mpfr_val, real2->mpfr_val);
+  #else
+  return mpf_cmp(real1->mpf_val, real2->mpf_val);
   #endif
 }
 

--- a/src/runtime/value-shadowstate/real.h
+++ b/src/runtime/value-shadowstate/real.h
@@ -53,6 +53,7 @@ void setReal(Real r, double bytes);
 
 double getDouble(Real real);
 int isNaN(Real real);
+int realCompare(Real real1, Real real2);
 
 void freeReal(Real real);
 void copyReal(Real src, Real dest);


### PR DESCRIPTION
Adds the --double-comparisons flag to revert to the old behavior. This
will be useful for improvement when you're unwilling to go over double
precision (Herbie, etc).