### PR TITLE
Fpcore ranges

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -65,6 +65,7 @@ Bool print_subexpr_locations = False;
 Bool output_mark_exprs = False;
 Bool detailed_ranges = False;
 Bool output_sexp = False;
+Bool fpcore_ranges = True;
 Bool sound_simplify = True;
 Bool shortmark_all_exprs = False;
 Bool mark_on_escape = True;
@@ -120,6 +121,7 @@ Bool hg_process_cmd_line_option(const HChar* arg){
   else if VG_XACT_CLO(arg, "--start-off", running_depth, 0) {}
   else if VG_XACT_CLO(arg, "--always-on", always_on, True) {}
   else if VG_XACT_CLO(arg, "--output-sexp", output_sexp, True) {}
+  else if VG_XACT_CLO(arg, "--no-fpcore-ranges", fpcore_ranges, False) {}
   else if VG_XACT_CLO(arg, "--no-mark-on-escape", mark_on_escape, False) {}
   else if VG_XACT_CLO(arg, "--no-compensation-detection", compensation_detection, False)
                        {}

--- a/src/options.h
+++ b/src/options.h
@@ -66,6 +66,7 @@ extern Bool print_subexpr_locations;
 extern Bool output_mark_exprs;
 extern Bool detailed_ranges;
 extern Bool output_sexp;
+extern Bool fpcore_ranges;
 extern Bool sound_simplify;
 extern Bool shortmark_all_exprs;
 extern Bool mark_on_escape;

--- a/src/runtime/op-shadowstate/output.c
+++ b/src/runtime/op-shadowstate/output.c
@@ -152,7 +152,7 @@ void writeOutput(void){
     }
     writeInfluences(fileD, filteredInfluences);
     if (output_sexp){
-      char endparens[] = "  )\n";
+      char endparens[] = "  )\n)";
       VG_(write)(fileD, endparens, sizeof(endparens) - 1);
     }
     char newline[] = "\n";
@@ -257,7 +257,8 @@ void writeOutput(void){
     }
     writeInfluences(fileD, filteredInfluences);
     if (output_sexp){
-      char endparens[] = "  )\n";
+      char endparens[] = "  )\n"
+        ")\n\n";
       VG_(write)(fileD, endparens, sizeof(endparens) - 1);
     }
   }
@@ -433,7 +434,6 @@ void writeInfluences(Int fileD, InfluenceList influences){
                 / global_error.num_evals,
                 local_error.max_error,
                 global_error.num_evals);
-      printBBuf(buf, "    )\n");
     } else {
       printBBuf(buf,
                 "\n"

--- a/src/runtime/op-shadowstate/output.c
+++ b/src/runtime/op-shadowstate/output.c
@@ -340,9 +340,72 @@ void writeInfluences(Int fileD, InfluenceList influences){
       printBBuf(buf,
                 "\n"
                 "     (expr\n"
-                "       (FPCore %s\n"
+                "       (FPCore %s\n",
+                varString);
+      if (fpcore_ranges){
+        printBBuf(buf,
+                  "         :pre (and");
+        for(int i = 0; i < numVars; ++i){
+          if (detailed_ranges){
+            printBBuf(buf, " (or (and (< ");
+            printBBufFloat(buf, totalRanges->neg_range.min);
+            printBBuf(buf, " %s) (< %s ", getVar(i), getVar(i));
+            printBBufFloat(buf, totalRanges->neg_range.max);
+            printBBuf(buf, ")) (and (< ");
+            printBBufFloat(buf, totalRanges->pos_range.min);
+            printBBuf(buf, " %s) (< %s ", getVar(i), getVar(i));
+            printBBufFloat(buf, totalRanges->pos_range.max);
+            printBBuf(buf, ")))");
+          } else {
+            printBBuf(buf, " (and (< ");
+            printBBufFloat(buf, totalRanges->pos_range.min);
+            printBBuf(buf, " %s) (< %s ", getVar(i), getVar(i));
+            printBBufFloat(buf, totalRanges->pos_range.max);
+            printBBuf(buf, "))");
+          }
+        }
+        printBBuf(buf, ")\n");
+      }
+      printBBuf(buf,
                 "         %s))\n",
-                varString, exprString);
+                exprString);
+      if (!fpcore_ranges){
+        printBBuf(buf,
+                  "     (var-ranges");
+        for(int i = 0; i < numVars; ++i){
+          if (detailed_ranges){
+            printBBuf(buf,
+                      "\n       (%s\n",
+                      getVar(i));
+            printBBuf(buf,
+                      "         (neg-range-min ");
+            printBBufFloat(buf, totalRanges->neg_range.min);
+            printBBuf(buf,")\n");
+            printBBuf(buf,
+                      "         (neg-range-max ");
+            printBBufFloat(buf, totalRanges->neg_range.max);
+            printBBuf(buf,")\n");
+            printBBuf(buf,
+                      "         (pos-range-min ");
+            printBBufFloat(buf, totalRanges->pos_range.min);
+            printBBuf(buf,")\n");
+            printBBuf(buf,
+                      "         (pos-range-max ");
+            printBBufFloat(buf, totalRanges->pos_range.max);
+            printBBuf(buf,"))");
+          } else {
+            printBBuf(buf,
+                      "         (range-min ");
+            printBBufFloat(buf, totalRanges->pos_range.min);
+            printBBuf(buf,")\n");
+            printBBuf(buf,
+                      "         (range-max ");
+            printBBufFloat(buf, totalRanges->pos_range.max);
+            printBBuf(buf,"))");
+          }
+        }
+        printBBuf(buf, ")\n");
+      }
       printBBuf(buf,
                 "     (function \"%s\")\n"
                 "     (filename \"%s\")\n"

--- a/src/runtime/op-shadowstate/output.c
+++ b/src/runtime/op-shadowstate/output.c
@@ -343,7 +343,7 @@ void writeInfluences(Int fileD, InfluenceList influences){
                 "     (expr\n"
                 "       (FPCore %s\n",
                 varString);
-      if (fpcore_ranges){
+      if (fpcore_ranges && use_ranges){
         printBBuf(buf,
                   "         :pre (and");
         for(int i = 0; i < numVars; ++i){

--- a/src/runtime/op-shadowstate/output.c
+++ b/src/runtime/op-shadowstate/output.c
@@ -370,7 +370,7 @@ void writeInfluences(Int fileD, InfluenceList influences){
       printBBuf(buf,
                 "         %s))\n",
                 exprString);
-      if (!fpcore_ranges){
+      if (!fpcore_ranges && use_ranges){
         printBBuf(buf,
                   "     (var-ranges");
         for(int i = 0; i < numVars; ++i){
@@ -437,10 +437,36 @@ void writeInfluences(Int fileD, InfluenceList influences){
     } else {
       printBBuf(buf,
                 "\n"
-                "    (FPCore %s\n"
-                "     %s)\n",
-                varString, exprString);
-      if (numVars > 0){
+                "    (FPCore %s\n",
+                varString);
+      if (fpcore_ranges && use_ranges){
+        printBBuf(buf,
+                  "      :pre (and");
+        for(int i = 0; i < numVars; ++i){
+          if (detailed_ranges){
+            printBBuf(buf, " (or (and (< ");
+            printBBufFloat(buf, totalRanges->neg_range.min);
+            printBBuf(buf, " %s) (< %s ", getVar(i), getVar(i));
+            printBBufFloat(buf, totalRanges->neg_range.max);
+            printBBuf(buf, ")) (and (< ");
+            printBBufFloat(buf, totalRanges->pos_range.min);
+            printBBuf(buf, " %s) (< %s ", getVar(i), getVar(i));
+            printBBufFloat(buf, totalRanges->pos_range.max);
+            printBBuf(buf, ")))");
+          } else {
+            printBBuf(buf, " (and (< ");
+            printBBufFloat(buf, totalRanges->pos_range.min);
+            printBBuf(buf, " %s) (< %s ", getVar(i), getVar(i));
+            printBBufFloat(buf, totalRanges->pos_range.max);
+            printBBuf(buf, "))");
+          }
+        }
+        printBBuf(buf, ")\n");
+      }
+      printBBuf(buf,
+                "         %s)\n",
+                exprString);
+      if (numVars > 0 && !fpcore_ranges && use_ranges){
         writeRanges(buf, numVars, totalRanges, problematicRanges);
         (void)problematicRanges;
         (void)totalRanges;

--- a/src/runtime/shadowop/shadowop.c
+++ b/src/runtime/shadowop/shadowop.c
@@ -124,7 +124,14 @@ VG_REGPARM(1) ShadowTemp* executeShadowOp(ShadowOpInfoInstance* infoInstance){
 ShadowTemp* getArg(int argIdx, int numChannels, FloatType argPrecision,
                    IRTemp argTemp){
   if (argTemp == -1 ||
-      shadowTemps[argTemp] == NULL){
+      shadowTemps[argTemp] == NULL ||
+      shadowTemps[argTemp]->num_vals != numChannels){
+    if (argTemp != -1 && shadowTemps[argTemp] != NULL &&
+        shadowTemps[argTemp]->num_vals != numChannels){
+      /* VG_(umsg)("WARNING: hit a shadow value mismatch. Bits were treated as different types of floats at different times.\n"); */
+      disownShadowTemp(shadowTemps[argTemp]);
+      shadowTemps[argTemp] = NULL;
+    }
     ShadowTemp* result = mkShadowTemp(numChannels);
     if (PRINT_TEMP_MOVES){
       VG_(printf)("Making shadow temp %p (%d vals) for argument %d\n",
@@ -150,11 +157,11 @@ ShadowTemp* getArg(int argIdx, int numChannels, FloatType argPrecision,
     }
     return result;
   } else {
-    tl_assert2(shadowTemps[argTemp]->num_vals == numChannels,
-               "Got a temp with the wrong number of shadows for arg %d! "
-               "Expected %d shadows, got %d from temp %d",
-               argIdx, numChannels, shadowTemps[argTemp]->num_vals,
-               argTemp);
+    /* tl_assert2(shadowTemps[argTemp]->num_vals == numChannels, */
+    /*            "Got a temp with the wrong number of shadows for arg %d! " */
+    /*            "Expected %d shadows, got %d from temp %d", */
+    /*            argIdx, numChannels, shadowTemps[argTemp]->num_vals, */
+    /*            argTemp); */
     return shadowTemps[argTemp];
   }
 }


### PR DESCRIPTION
Adds fpcore ranges mode, and makes it the default. This mode outputs ranges as `:pre` attributes in FPCore, instead of as separate metadata. The old behaviour is available with the flag `--no-fpcore-ranges`.