### PR TITLE
check if `git -C` is implemented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ all: compile
 # repo currently exists.
 valgrind/README:
 # Check out valgrind from source.
+	git -C . --help &> /dev/null || { echo "Git version with '-C' switch support is mandatory"; exit 1; }
 	git clone $(VALGRIND_REPO_LOCATION) valgrind
 	git -C valgrind checkout $(VALGRIND_REVISION)
 	cd setup && ./modify_makefiles.sh


### PR DESCRIPTION
If herbgrind is being built on (latest) centos7, the system-default git doesn't support `-C` option.
In the first `make` run it (correctly) fails, but in any following run it will just check presence of `valgrind/README` and then produce broken build without any warning.

can be reproduced with this git:

```
git-1.8.3.1-23.el7_8.x86_64
```

```
jose@koiosvm2:~/projects/herbgrind$ cat /etc/redhat-release 
CentOS Linux release 7.8.2003 (Core)
jose@koiosvm2:~/projects/herbgrind$
```